### PR TITLE
[#6] - Adding in NiFi installer function

### DIFF
--- a/conf/service-installer.conf
+++ b/conf/service-installer.conf
@@ -1,11 +1,17 @@
 [SERVICES]
-service-names=["ZEPPELIN"]
+service-names=["ZEPPELIN", "NIFI"]
 
 
 [ZEPPELIN]
 install-commands=[ "hdp-select status hadoop-client | sed 's/hadoop-client - \\([0-9]\\.[0-9]\\).*/\\1/'", "cp -r ../ambari-services/ambari-zeppelin-service /var/lib/ambari-server/resources/stacks/HDP/$VERSION/services/ZEPPELIN", "ambari-server restart"]
 server=localhost
 port=9995
+
+
+[NIFI]
+install-commands=[ "hdp-select status hadoop-client | sed 's/hadoop-client - \\([0-9]\\.[0-9]\\).*/\\1/'", "rm -rf /var/lib/ambari-server/resources/stacks/HDP/$VERSION/services/NIFI", "cp -r ../ambari-services/ambari-nifi-service /var/lib/ambari-server/resources/stacks/HDP/$VERSION/services/NIFI", "ambari-server restart"]
+server=localhost
+port=9090
 
 # Repo Links for HDP-SELECT
 [HDP-SELECT]

--- a/scripts/service_installer.py
+++ b/scripts/service_installer.py
@@ -71,7 +71,6 @@ def is_ambari_installed():
 		return True
 
 
-
 def install_zeppelin(conf_dir):
 	
 	if not conf_dir.endswith('/'):
@@ -126,6 +125,65 @@ def install_zeppelin(conf_dir):
 	elif cont == 'y':
 		return True
 
+
+
+def install_nifi(conf_dir):
+	
+	if not conf_dir.endswith('/'):
+		conf_dir += '/'
+	
+	if not is_ambari_installed():
+		raise EnvironmentError('You must install the demo on the same node as the Ambari server. Install Ambari here or move to another node with Ambari installed before continuing')
+	
+	
+	if not is_hdp_select_installed():
+		installed = install_hdp_select()
+		if not installed:
+			raise EnvironmentError('hdp-select could not be installed. Please install it manually and then re-run the setup.')
+
+	conf = config.read_config(conf_dir + 'service-installer.conf')
+	cmds = json.loads(conf['NIFI']['install-commands'])
+	
+	sh = Shell()
+#	print(sh.run('pwd')[0])
+	version = sh.run(cmds[0])
+#	print("HDP-VERSION: " + str(version[0]))
+	fixed_copy = cmds[2].replace('$VERSION', str(version[0])).replace('\n', '')
+#	print('FIXED COPY COMMAND: ' + fixed_cmd)
+	fixed_remove = cmds[1].replace('$VERSION', str(version[0])).replace('\n', '')
+	remove = sh.run(fixed_remove)
+	copy = sh.run(fixed_copy)
+#	print("COPY OUTPUT: " + copy[0])
+	restart = sh.run(cmds[3])
+#	print("Restart output: " + restart[0])
+
+
+	print("Please open the Ambari Interface and manually deploy the NiFi Service.")
+	raw_input("Press enter twice to continue...")
+	raw_input("Press enter once to continue...")
+	
+#	 We've copied the necessary files. Once that completes we need to add it to Ambari
+	
+	print('Checking to make sure service is installed')
+	ambari = config.read_config(conf_dir + 'global-config.conf')['AMBARI']
+	installed = check_ambari_service_installed('NIFI', ambari)
+	cont = ''
+	if not installed:
+		print('Unable to contact Ambari Server. Unsure whether or not Zeppelin was installed')
+		while not (cont == 'y' or cont == 'n'):
+			cont = raw_input('Continue attempt to set up NiFi for demo?(y/n)')
+			if not (cont == 'y' or cont == 'n'):
+				print('Please enter "y" or "n"')
+	else:
+		cont = 'y'
+	
+	if cont == 'n':
+		return False
+	elif cont == 'y':
+		return True
+
+
+	
 def check_ambari_service_installed(service_name, ambari_config):
 	
 	curl = CurlClient(username=ambari_config['username'], password=ambari_config['password'], port=ambari_config['port'], server=ambari_config['server'], proto=ambari_config['proto'])


### PR DESCRIPTION
The goal here is similar to the Zeppelin service.

We want to be able to add NiFi as an Ambari service to whichever cluster we desire.

Resolves #6 