### PR TITLE
[#7] - Adding NiFi Templates

### DIFF
--- a/conf/service-installer.conf
+++ b/conf/service-installer.conf
@@ -13,6 +13,7 @@ port=9995
 install-commands=[ "hdp-select status hadoop-client | sed 's/hadoop-client - \\([0-9]\\.[0-9]\\).*/\\1/'", "rm -rf /var/lib/ambari-server/resources/stacks/HDP/$VERSION/services/NIFI", "cp -r ../ambari-services/ambari-nifi-service /var/lib/ambari-server/resources/stacks/HDP/$VERSION/services/NIFI", "ambari-server restart"]
 server=localhost
 port=9090
+protocol=http
 
 # Repo Links for HDP-SELECT
 [HDP-SELECT]

--- a/scripts/service_installer.py
+++ b/scripts/service_installer.py
@@ -98,10 +98,34 @@ def post_notebook(notebook_path):
 #		log failed note creation (and to import manually)
 		return False
 
+def add_nifi_templates():
+	all_success = True
+	template_dir = config.get_conf_dir() + 'nifi/templates'
+	for item in os.listdir(template_dir):
+		item_path = template_dir + '/' + item
+		if os.path.isfile(item_path) and str(item).endswith('.xml'):
+			result = post_template(item_path)
+			if not result:
+				all_success = False
+	return all_success
+
+
+def post_template(template_path):
+	conf = config.read_config('service-installer.conf')['NIFI']
+	client = CurlClient(proto=conf['protocol'], server=conf['server'], port=int(conf['port']))
+	path = '/nifi-api/controller/templates'
+	
+	output = client.make_request('POST', path, options='-i -F template=@' + template_path )
+	if '201 Created' in output[0] or '200 OK' in output[0]:
+#		log successful note created
+		return True
+	else:
+#		log failed note creation (and to import manually)
+		return False
+
 def install_zeppelin():
 	if not is_ambari_installed():
 		raise EnvironmentError('You must install the demo on the same node as the Ambari server. Install Ambari here or move to another node with Ambari installed before continuing')
-	
 	
 	if not is_hdp_select_installed():
 		installed = install_hdp_select()

--- a/scripts/service_installer.py
+++ b/scripts/service_installer.py
@@ -150,11 +150,8 @@ def install_zeppelin():
 
 
 
-def install_nifi(conf_dir):
-	
-	if not conf_dir.endswith('/'):
-		conf_dir += '/'
-	
+def install_nifi():
+
 	if not is_ambari_installed():
 		raise EnvironmentError('You must install the demo on the same node as the Ambari server. Install Ambari here or move to another node with Ambari installed before continuing')
 	
@@ -164,7 +161,7 @@ def install_nifi(conf_dir):
 		if not installed:
 			raise EnvironmentError('hdp-select could not be installed. Please install it manually and then re-run the setup.')
 
-	conf = config.read_config(conf_dir + 'service-installer.conf')
+	conf = config.read_config('service-installer.conf')
 	cmds = json.loads(conf['NIFI']['install-commands'])
 	
 	sh = Shell()
@@ -188,7 +185,7 @@ def install_nifi(conf_dir):
 #	 We've copied the necessary files. Once that completes we need to add it to Ambari
 	
 	print('Checking to make sure service is installed')
-	ambari = config.read_config(conf_dir + 'global-config.conf')['AMBARI']
+	ambari = config.read_config('global-config.conf')['AMBARI']
 	installed = check_ambari_service_installed('NIFI', ambari)
 	cont = ''
 	if not installed:

--- a/tests/test_service_installer.py
+++ b/tests/test_service_installer.py
@@ -175,7 +175,7 @@ class TestNiFiInstall(unittest.TestCase):
 	@mock.patch('scripts.service_installer.is_ambari_installed', return_value=False)
 	def test_nifi_ambari_bad(self, mock):
 		try:
-			service_installer.install_nifi('../conf/')
+			service_installer.install_nifi()
 			self.fail('Cannot continue installation without Ambari')
 		except EnvironmentError as e:
 			assert str(e.message) == 'You must install the demo on the same node as the Ambari server. Install Ambari here or move to another node with Ambari installed before continuing'
@@ -185,7 +185,7 @@ class TestNiFiInstall(unittest.TestCase):
 	@mock.patch('scripts.service_installer.install_hdp_select', return_value=False)
 	def test_nifi_ambari_good(self, mock, mock2, mock3): #Also HDP select bad
 		try:
-			service_installer.install_nifi('../conf')
+			service_installer.install_nifi()
 			self.fail('Cannot continue installation without hdp-select')
 		except EnvironmentError as e:
 			assert str(e.message) == 'hdp-select could not be installed. Please install it manually and then re-run the setup.'
@@ -196,7 +196,7 @@ class TestNiFiInstall(unittest.TestCase):
 	@mock.patch('scripts.service_installer.check_ambari_service_installed', return_value=True)
 	@mock.patch('__builtin__.raw_input', return_value='y')
 	def test_nifi_check_is_good(self, mock, mock2, mock3, mock4, mock5):
-			assert service_installer.install_nifi('../conf') == True
+			assert service_installer.install_nifi() == True
 			
 			
 	@mock.patch('scripts.service_installer.is_ambari_installed', return_value=True)
@@ -205,7 +205,7 @@ class TestNiFiInstall(unittest.TestCase):
 	@mock.patch('scripts.service_installer.check_ambari_service_installed', return_value=False)
 	@mock.patch('__builtin__.raw_input', side_effect=['\n', '\n', 'v', 'y'])
 	def test_nifi_no_ambari_contact_continue(self, mock, mock2, mock3, mock4, mock5):
-			assert service_installer.install_nifi('../conf') == True
+			assert service_installer.install_nifi() == True
 	
 	@mock.patch('scripts.service_installer.is_ambari_installed', return_value=True)
 	@mock.patch('scripts.service_installer.is_hdp_select_installed', return_value=True)
@@ -213,7 +213,7 @@ class TestNiFiInstall(unittest.TestCase):
 	@mock.patch('scripts.service_installer.check_ambari_service_installed', return_value=False)
 	@mock.patch('__builtin__.raw_input', side_effect=['\n', '\n', 'v', 'n'])
 	def test_nifi_no_ambari_contact_no_continue(self, mock, mock2, mock3, mock4, mock5):
-			assert service_installer.install_nifi('../conf') == False
+			assert service_installer.install_nifi() == False
 
 class TestZeppelinAddNotebook(unittest.TestCase):
 	

--- a/tests/test_service_installer.py
+++ b/tests/test_service_installer.py
@@ -251,7 +251,45 @@ class TestZeppelinAddNotebook(unittest.TestCase):
 		assert service_installer.post_notebook(paths[1])
 		
 		assert service_installer.post_notebook(paths[2])
+
 		
+class TestNiFiAddTemplate(unittest.TestCase):
+	
+	@mock.patch('scripts.curl_client.CurlClient.make_request', return_value=['201 Created', ''])
+	@mock.patch('os.path.isfile', return_value=True)
+	@mock.patch('os.listdir', return_value=['template1.xml', 'template2.xml', 'template3.xml'])
+	def test_good(self, mock1, mock2, mock3):
+		assert (service_installer.add_nifi_templates())
+		
+	@mock.patch('scripts.curl_client.CurlClient.make_request', return_value=['500 err', ''])
+	@mock.patch('os.path.isfile', return_value=True)
+	@mock.patch('os.listdir', return_value=['template1.xml', 'template2.xml', 'template3.xml'])
+	def test_bad(self, mock1, mock2, mock3):
+		assert (not service_installer.add_nifi_templates())
+	
+	@mock.patch('scripts.curl_client.CurlClient.make_request', return_value=['500 err', ''])
+	@mock.patch('os.path.isfile', return_value=True)
+	@mock.patch('os.listdir', return_value=['template1.xml', 'template2.xml', 't3.xml'])
+	def test_mixed(self, mock1, mock2, mock3):
+		assert (not service_installer.add_nifi_templates())
+		
+	@mock.patch('scripts.curl_client.CurlClient.make_request', side_effect=[['500 err', ''], ['201 Created', ''], ['201 Created', '']])
+	@mock.patch('os.path.isfile', return_value=True)
+	@mock.patch('os.listdir', return_value=['template1.xml', 'template2.xml', 'note3.xml'])
+	def test_mixed_response(self, mock1, mock2, mock3):
+		assert (not service_installer.add_nifi_templates())
+		
+	@mock.patch('scripts.curl_client.CurlClient.make_request', side_effect=[['500 err', ''], ['201 Created', ''], ['201 Created', '']])
+	@mock.patch('os.path.isfile', return_value=True)
+	def test_post_notebook(self, mock1, mock2):
+		
+		paths = ['template1.xml', 'template2.xml', 'note3.xml']
+		assert not service_installer.post_notebook(paths[0])
+		
+		assert service_installer.post_notebook(paths[1])
+		
+		assert service_installer.post_notebook(paths[2])
+
 		
 		
 			


### PR DESCRIPTION
This feature addition allows the service installer to push notebooks onto an existing NiFi installation via a POST to /nifi-api/controller/templates

Resolves #7 